### PR TITLE
🔧 Fix claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,7 @@
   },
   "sandbox": {
     "filesystem": {
-      "allowRead": [".", "~/.npmrc"],
+      "allowRead": [".", "~/.npm/", "~/.npmrc"],
       "allowWrite": ["~/.npm/"]
     },
     "network": {


### PR DESCRIPTION
## Summary

- `.claude/settings.json` の sandbox `allowRead` に `~/.npm/` を追加

Generated with Claude Code